### PR TITLE
Adding support for collateral auction

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -2,6 +2,15 @@
 type CollateralAuction @entity {
   id: ID!
 
+  " Auction Number as Int "
+  number: BigInt!
+
+  lot: BigInt!
+  bid: BigInt!
+  tab: BigInt!
+  usr: Bytes!
+  gal: Bytes!
+
   " Collateral type "
   collateral: CollateralType!
 

--- a/src/mappings/modules/collateral/flip.ts
+++ b/src/mappings/modules/collateral/flip.ts
@@ -32,6 +32,12 @@ export function handleKick(event: Kick): void {
   if (collateral != null) {
     // TODO: Save new auction data
     let bid = new CollateralAuction(event.params.id.toString())
+    bid.number = event.params.id
+    bid.lot = event.params.lot
+    bid.bid = event.params.bid
+    bid.tab = event.params.tab
+    bid.usr = event.params.usr
+    bid.gal = event.params.gal
     bid.collateral = collateral.id
 
     collateral.auctionCount = collateral.auctionCount.plus(integer.ONE)


### PR DESCRIPTION
This should allow for users to be able to order CollateralAuction events, since the "id" field of entities are interpreted as strings and not integers.

This avoids the issue of having "99" being interpreted as "greater" than "400" since in string terms, 9 > 4.

Still have no clue how/why SystemState.collateralAuctionCount isn't lined up with the ID's of CollateralAuction events, but there's a chance that this new `number` field will be in sync.