### PR TITLE
Experimental fix for random matchstick errors

### DIFF
--- a/tests/helpers/mockedFunctions.ts
+++ b/tests/helpers/mockedFunctions.ts
@@ -1,0 +1,13 @@
+import { tests } from "../../src/mappings/modules/tests";
+import { Address, ethereum, BigInt } from "@graphprotocol/graph-ts";
+
+export function mockDebt(): void{
+  let debtResult = BigInt.fromString("100").toI32()
+  tests.helpers.contractCalls.mockFunction(
+      Address.fromString("0x35d1b3f3d7966a1dfe207aa4514c12a259a0492b"),
+      'debt',
+      'debt():(uint256)',
+      [],
+      [ethereum.Value.fromI32(debtResult)]
+    )
+}

--- a/tests/mappings/modules/core/vat/handleFile.test.ts
+++ b/tests/mappings/modules/core/vat/handleFile.test.ts
@@ -4,6 +4,7 @@ import { CollateralType } from "../../../../../generated/schema";
 import { LogNote } from "../../../../../generated/Vat/Vat";
 import { handleFile } from "../../../../../src/mappings/modules/core/vat";
 import { tests } from "../../../../../src/mappings/modules/tests";
+import { mockDebt } from "../../../../helpers/mockedFunctions";
 
 
 function strRadToBytes(value: string): Bytes {
@@ -26,6 +27,7 @@ test(
       arg2,
     ]));
 
+    mockDebt()
     handleFile(event);
 
     assert.fieldEquals("SystemState", "current", "totalDebtCeiling", "100.5");

--- a/tests/mappings/modules/core/vat/handleFold.test.ts
+++ b/tests/mappings/modules/core/vat/handleFold.test.ts
@@ -4,6 +4,7 @@ import { CollateralType, User } from "../../../../../generated/schema";
 import { LogNote } from "../../../../../generated/Vat/Vat";
 import { handleFold } from "../../../../../src/mappings/modules/core/vat";
 import { tests } from "../../../../../src/mappings/modules/tests";
+import { mockDebt } from "../../../../helpers/mockedFunctions";
 
 function createEvent(ilk: string, u: string, rate: string): LogNote {
   let sig = tests.helpers.params.getBytes("sig", Bytes.fromHexString("0xa1a2a3a4"));
@@ -45,6 +46,7 @@ test("Vat#handleFold",
       rate,
     )
 
+    mockDebt()
     handleFold(event)
 
     assert.fieldEquals("CollateralType", collateralTypeId, "rate", "0.6");

--- a/tests/mappings/modules/core/vat/handleFrob.test.ts
+++ b/tests/mappings/modules/core/vat/handleFrob.test.ts
@@ -5,6 +5,7 @@ import { CollateralType, Vault } from "../../../../../generated/schema";
 import { LogNote } from "../../../../../generated/Vat/Vat";
 import { handleFrob } from "../../../../../src/mappings/modules/core/vat";
 import { tests } from "../../../../../src/mappings/modules/tests";
+import { mockDebt } from "../../../../helpers/mockedFunctions";
 
 // handleFrob
 // when collateralType exist
@@ -53,6 +54,7 @@ test("Vat#handleFrob: when both collateralType and vault exist, it updates both"
   let dart = Bytes.fromUint8Array(Bytes.fromBigInt(BigInt.fromString("200500000000000000000")).reverse())
   let event = createEvent(signature, collateralTypeId, urnId, dink, dart)
 
+  mockDebt()
   handleFrob(event);
 
   // test mapper is not creating new entities

--- a/tests/mappings/modules/core/vat/handleGrab.test.ts
+++ b/tests/mappings/modules/core/vat/handleGrab.test.ts
@@ -2,6 +2,7 @@ import { Bytes } from "@graphprotocol/graph-ts";
 import { test } from "matchstick-as";
 import { LogNote } from "../../../../../generated/Vat/Vat";
 import { tests } from "../../../../../src/mappings/modules/tests";
+import { mockDebt } from "../../../../helpers/mockedFunctions";
 
 test("Vat # handleGrab : Liquidates a Vault", () => {
 	let sig = tests.helpers.params.getBytes("sig", Bytes.fromUTF8("sig"));
@@ -13,4 +14,6 @@ test("Vat # handleGrab : Liquidates a Vault", () => {
 	let event = changetype<LogNote>(tests.helpers.events.getNewEvent([
 
 	]))
+
+	mockDebt()
 })

--- a/tests/mappings/modules/core/vat/handleInit.test.ts
+++ b/tests/mappings/modules/core/vat/handleInit.test.ts
@@ -4,6 +4,7 @@ import { test, clearStore } from "matchstick-as";
 import { LogNote } from "../../../../../generated/Vat/Vat";
 import { handleInit } from "../../../../../src/mappings/modules/core/vat";
 import { tests } from "../../../../../src/mappings/modules/tests";
+import { mockDebt } from "../../../../helpers/mockedFunctions"
 
 test(
   "Vat#handleInit creates initial CollateralType and updates SystemState",
@@ -22,16 +23,7 @@ test(
       data,
     ]));
 
-    let debtResult = BigInt.fromString("100").toI32()
-
-    tests.helpers.contractCalls.mockFunction(
-      Address.fromString("0x35d1b3f3d7966a1dfe207aa4514c12a259a0492b"),
-      'debt',
-      'debt():(uint256)',
-      [],
-      [ethereum.Value.fromI32(debtResult)]
-    )
-
+    mockDebt()
     handleInit(event);
 
     let collateralTypeFields = new TypedMap<string, string>();

--- a/tests/mappings/modules/core/vat/handleSuck.test.ts
+++ b/tests/mappings/modules/core/vat/handleSuck.test.ts
@@ -4,6 +4,7 @@ import { User } from "../../../../../generated/schema";
 import { LogNote } from "../../../../../generated/Vat/Vat";
 import { handleSuck } from "../../../../../src/mappings/modules/core/vat";
 import { tests } from "../../../../../src/mappings/modules/tests";
+import { mockDebt } from "../../../../helpers/mockedFunctions";
 
 function createEvent(u: string, v: string, rad: string): LogNote {
   let sig = tests.helpers.params.getBytes("sig", Bytes.fromHexString("0x1a0b287e"));
@@ -36,6 +37,7 @@ test("Vat#handleSuck",
     user2.dai = BigDecimal.fromString("1000")
     user2.save()
 
+    mockDebt()
     handleSuck(event)
 
     assert.fieldEquals("User", v, "dai", "1100.5")


### PR DESCRIPTION
This is an experimental fix for the random `mockFunction before calling` errors during the unit test.

Explanation (guess):
I think that either the order of testing always changes or multiple test files are ran parallel by Matchstick. Since we only mocked the debt function once (test for handleInit), this will randomly fail.

Solution:
I implemented a helper function and call it before every possible function call to getSystemState(), since this function requires the try_debt call

Additionaly:
Since we splitted up the tests, I think it would be useful to create a helper file or folder (like in this PR).