### PR TITLE
Updated CollateralTransferLog

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -466,7 +466,9 @@ type CollateralTransferLog implements CollateralLog @entity{
   src: Bytes!
   dst: Bytes!
   amount: BigDecimal!
-  collateral: CollateralType!
+  collateral: Collateral!
+  srcCollateral: Collateral!
+  dstCollateral: Collateral!
   block: BigInt!
   timestamp: BigInt!
   transaction: Bytes!

--- a/schema.graphql
+++ b/schema.graphql
@@ -461,14 +461,18 @@ type CollateralChangeLog implements CollateralLog @entity{
   transaction: Bytes!
 }
 
+enum Direction {
+  IN 
+  OUT
+}
+
 type CollateralTransferLog implements CollateralLog @entity{
   id: ID!
   src: Bytes!
   dst: Bytes!
   amount: BigDecimal!
   collateral: Collateral!
-  srcCollateral: Collateral!
-  dstCollateral: Collateral!
+  direction: Direction!
   block: BigInt!
   timestamp: BigInt!
   transaction: Bytes!

--- a/src/mappings/modules/core/vat.ts
+++ b/src/mappings/modules/core/vat.ts
@@ -174,8 +174,7 @@ export function handleFlux(event: LogNote): void {
   srcLog.dst = dstAddress
   srcLog.amount = Δwad
   srcLog.collateral = srcCollateral.id
-  srcLog.srcCollateral = srcCollateral.id
-  srcLog.dstCollateral = dstCollateral.id
+  srcLog.direction = "OUT"
   srcLog.block = event.block.number
   srcLog.timestamp = event.block.timestamp
   srcLog.transaction = event.transaction.hash 
@@ -186,8 +185,7 @@ export function handleFlux(event: LogNote): void {
   dstLog.dst = dstAddress
   dstLog.amount = Δwad
   dstLog.collateral = dstCollateral.id
-  dstLog.srcCollateral = srcCollateral.id
-  dstLog.dstCollateral = dstCollateral.id
+  dstLog.direction = "IN"
   dstLog.block = event.block.number
   dstLog.timestamp = event.block.timestamp
   dstLog.transaction = event.transaction.hash 

--- a/src/mappings/modules/core/vat.ts
+++ b/src/mappings/modules/core/vat.ts
@@ -169,14 +169,29 @@ export function handleFlux(event: LogNote): void {
   dstCollateral.modifiedAtTransaction = event.transaction.hash
   dstCollateral.save()
 
-  let log = new CollateralTransferLog(event.transaction.hash.toHex() + '-' + event.logIndex.toString() + '-5')
-  log.src = srcAddress
-  log.dst = dstAddress
-  log.amount = Δwad
-  log.collateral = ilk
-  log.block = event.block.number
-  log.timestamp = event.block.timestamp
-  log.transaction = event.transaction.hash 
+  let srcLog = new CollateralTransferLog(event.transaction.hash.toHex() + '-' + event.logIndex.toString() + '-5.0')
+  srcLog.src = srcAddress
+  srcLog.dst = dstAddress
+  srcLog.amount = Δwad
+  srcLog.collateral = srcCollateral.id
+  srcLog.srcCollateral = srcCollateral.id
+  srcLog.dstCollateral = dstCollateral.id
+  srcLog.block = event.block.number
+  srcLog.timestamp = event.block.timestamp
+  srcLog.transaction = event.transaction.hash 
+  srcLog.save()
+
+  let dstLog = new CollateralTransferLog(event.transaction.hash.toHex() + '-' + event.logIndex.toString() + '-5.1')
+  dstLog.src = srcAddress
+  dstLog.dst = dstAddress
+  dstLog.amount = Δwad
+  dstLog.collateral = dstCollateral.id
+  dstLog.srcCollateral = srcCollateral.id
+  dstLog.dstCollateral = dstCollateral.id
+  dstLog.block = event.block.number
+  dstLog.timestamp = event.block.timestamp
+  dstLog.transaction = event.transaction.hash 
+  dstLog.save()
 }
 
 // Transfer stablecoin between users


### PR DESCRIPTION
I updated the CollateralTransferLog entity in schema.graphql so that it can use the CollateralLog Interface.
To get the full picture, i created two CollateralTransferLogs in the handleFlux, so that a CollateralLog is created for both sender and receiver. These CollateralLogs will then be shown in the Collateral entity under logs for both users